### PR TITLE
Allow null values for timestamp

### DIFF
--- a/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
+++ b/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
@@ -60,6 +60,9 @@ class Timestamp extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+	if(is_null($value)) {
+		return null;
+	}
         $dt = new \DateTime();
         $dt->setTimestamp($value);
         return $dt;

--- a/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
+++ b/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
@@ -47,7 +47,7 @@ class Timestamp extends Type
         if ($value instanceof \DateTime) {
             return $value->getTimestamp();
         }
-        return (int)$value;
+        return is_null($value) ? $value : (int)$value;
     }
 
     /**

--- a/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
+++ b/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
@@ -60,7 +60,7 @@ class Timestamp extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-	if(is_null($value)) {
+	if (is_null($value)) {
 		return null;
 	}
         $dt = new \DateTime();


### PR DESCRIPTION
Hello @mmerian ,

I noticed that if we provide a null value to the type, it converts to 0. This checks the value for null and leave it at that if that's the case.