### PR TITLE
Added getBindingType && requiresSQLCommentHint methods

### DIFF
--- a/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
+++ b/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
@@ -69,4 +69,20 @@ class Timestamp extends Type
 
         return $dt;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBindingType()
+    {
+        return \PDO::PARAM_INT;
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
DBAL\Types\Type class defines few other methods that could/should be overrided